### PR TITLE
feat: Implement iframe sandbox toggle functionality


### DIFF
--- a/README.md
+++ b/README.md
@@ -105,15 +105,15 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 
 ---
 
-[ ] Add Base64 support: detect ?b64= param and auto-decode payloads.
+[x] Add Base64 support: detect ?b64= param and auto-decode payloads.
 [ ] Implement Gist Loader: support ?gist=<id> to fetch and render external code.
 [ ] Enhance Sandboxing: toggle sandbox attribute for <iframe> (allow-scripts vs. strict).
 [x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
 [-] Improve UX: add “Edit ↻” button to sync textarea changes back to the URL. (Editor and Render button added, direct URL sync pending)
-[ ] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
+[x] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
 [ ] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
 [ ] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.
 [ ] Set up CSP Headers: configure safe Content-Security-Policy for public usage.
-[ ] Document API: detail query parameters and behaviors in README.
+[x] Document API: detail query parameters and behaviors in README.
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Intuit is a minimalist web tool that decodes and renders HTML content passed as 
 - Render HTML content from URL parameters.
 - Real-time rendering of HTML within an iframe.
 - Clean and user-friendly interface for ease of use.
+- **Configurable Sandbox:** Control the `iframe` sandbox policy. By default, scripts are disabled for security. A toggle allows enabling scripts (`allow-scripts`, `allow-same-origin`, `allow-popups`, `allow-forms`) for testing snippets that require them. Use with caution with untrusted HTML.
 
 ## Intuit for LLM-Powered Agents
 
@@ -73,6 +74,7 @@ Beyond URL parameters, Intuit offers:
 *   **HTML Editor**: A textarea to directly type or paste HTML.
 *   **Render Button**: Renders the content from the HTML editor into the preview iframe.
 *   **Copy Link Button**: Generates a shareable URL with the current content of the HTML editor (URL-encoded into the `data` parameter) and copies it to the clipboard.
+*   **Sandbox Toggle**: A checkbox ("Allow Scripts") to switch the preview `iframe`'s sandbox settings. Unchecked (default) provides a strict sandbox. Checked allows scripts, same-origin operations, popups, and forms.
 
 ## Installation
 
@@ -110,7 +112,7 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 
 [x] Add Base64 support: detect ?b64= param and auto-decode payloads.
 [x] Implement Gist Loader: support ?gist=<id> to fetch and render external code.
-[ ] Enhance Sandboxing: toggle sandbox attribute for <iframe> (allow-scripts vs. strict).
+[x] Enhance Sandboxing: toggle sandbox attribute for <iframe> (allow-scripts vs. strict).
 [x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
 [-] Improve UX: add “Edit ↻” button to sync textarea changes back to the URL. (Editor and Render button added, direct URL sync pending)
 [x] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ Intuit can be controlled via URL query parameters:
 
 *   **`b64`**: Provides Base64-encoded HTML content to be rendered.
     *   Example: `...?b64=PGgxPkhlbGxvIFdvcmxkPC9oMT4=` (for `<h1>Hello World</h1>`)
-    *   **Note**: If both `data` and `b64` parameters are present in the URL, the `data` parameter will take precedence. If neither is present, the content from the live editor (if any) will be rendered on page load.
+
+*   **`gist`**: Provides a GitHub Gist ID to fetch and render. Intuit will look for the first file ending with `.html` within the Gist's files, retrieve its raw content, and render it.
+    *   Example: `...?gist=3f3c76c07548eb884388600d877f7691` (loads `<h1>Hello Gist!</h1>` from the Gist)
+    *   **Note**: If multiple content parameters (`data`, `b64`, `gist`) are present, `data` takes precedence, then `b64`, and then `gist`. If none of these are present, the content from the live editor (if any) will be rendered on page load.
 
 ### Live Editor and Tools
 
@@ -106,7 +109,7 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 ---
 
 [x] Add Base64 support: detect ?b64= param and auto-decode payloads.
-[ ] Implement Gist Loader: support ?gist=<id> to fetch and render external code.
+[x] Implement Gist Loader: support ?gist=<id> to fetch and render external code.
 [ ] Enhance Sandboxing: toggle sandbox attribute for <iframe> (allow-scripts vs. strict).
 [x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
 [-] Improve UX: add “Edit ↻” button to sync textarea changes back to the URL. (Editor and Render button added, direct URL sync pending)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Intuit is a minimalist web tool that decodes and renders HTML content passed as 
 - Real-time rendering of HTML within an iframe.
 - Clean and user-friendly interface for ease of use.
 
+## Intuit for LLM-Powered Agents
+
+Hey there, LLM-powered agent! If you're working with HTML generation, manipulation, or testing, you're going to find Intuit particularly helpful. Here's why:
+
+*   **Instant Visual Feedback:** Generated some HTML? Paste it (or its URL-encoded/Base64 representation) into Intuit via the editor or URL parameters (`data=` or `b64=`), and see it render *immediately*. No complex browser automation or headless setups needed for a quick visual check.
+
+*   **Effortless Debugging:** If your HTML output isn't quite right, Intuit provides a sandboxed environment to quickly inspect and debug your code. See exactly how the browser interprets your tags and styles.
+
+*   **Rapid Prototyping:** Need to create UI mockups, web components, or test out HTML-based responses? Use Intuit as your scratchpad. Iterate quickly without the overhead of a full development environment.
+
+*   **Shareable Previews:** Easily share your HTML creations. Construct a URL with your generated HTML and pass it to your human colleagues or for further processing. They can open it in any browser, anywhere.
+
+*   **Test Snippets in Isolation:** Got a small piece of HTML, a CSS style you want to try within a structure, or a tiny JavaScript interaction? Intuit is perfect for testing these snippets in isolation without interference from larger applications.
+
+*   **Zero Backend, Zero Fuss:** As a purely client-side tool, you don't need to worry about server setup, dependencies, or complex environments. If you can generate text and form a URL, you can use Intuit.
+
+Intuit empowers you to work more efficiently with HTML, providing a straightforward way to render, test, and share your web content.
+
 ## Use Cases
 
 ### Web Development

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Hey there, LLM-powered agent! If you're working with HTML generation, manipulati
 
 *   **Test Snippets in Isolation:** Got a small piece of HTML, a CSS style you want to try within a structure, or a tiny JavaScript interaction? Intuit is perfect for testing these snippets in isolation without interference from larger applications.
 
-*   **Zero Backend, Zero Fuss:** As a purely client-side tool, you don't need to worry about server setup, dependencies, or complex environments. If you can generate text and form a URL, you can use Intuit.
+*   **Zero Backend, Zero Fuss:** As a purely client-side tool, your primary requirement is the ability to make a GET request to access the Intuit URL (e.g., `https://username.github.io/intuit/` potentially with `?data=` or `?b64=` parameters). Once the page is loaded, all HTML, CSS, and basic JavaScript rendering happens directly within that browser environment. No server-side setup, no special permissions beyond web access – if you can form a URL and view a webpage, you can use Intuit.
 
 Intuit empowers you to work more efficiently with HTML, providing a straightforward way to render, test, and share your web content.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ Intuit is a minimalist web tool that decodes and renders HTML content passed as 
 2. Add your HTML content as a URL-encoded string in the `data` URL parameter like so:
 > https://franklinbaldo.github.io/intuit/?data=%3Ch1%3EHello%20World%3C/h1%3E
 
+## API
+
+### Query Parameters
+
+Intuit can be controlled via URL query parameters:
+
+*   **`data`**: Provides URL-encoded HTML content to be rendered.
+    *   Example: `...?data=%3Ch1%3EHello%20World%3C%2Fh1%3E`
+
+*   **`b64`**: Provides Base64-encoded HTML content to be rendered.
+    *   Example: `...?b64=PGgxPkhlbGxvIFdvcmxkPC9oMT4=` (for `<h1>Hello World</h1>`)
+    *   **Note**: If both `data` and `b64` parameters are present in the URL, the `data` parameter will take precedence. If neither is present, the content from the live editor (if any) will be rendered on page load.
+
+### Live Editor and Tools
+
+Beyond URL parameters, Intuit offers:
+
+*   **HTML Editor**: A textarea to directly type or paste HTML.
+*   **Render Button**: Renders the content from the HTML editor into the preview iframe.
+*   **Copy Link Button**: Generates a shareable URL with the current content of the HTML editor (URL-encoded into the `data` parameter) and copies it to the clipboard.
+
 ## Installation
 
 If you'd like to run Intuit locally:
@@ -61,3 +82,20 @@ Contributions, issues, and feature requests are welcome. Feel free to check the 
 ## Author
 
 Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
+
+## TODO
+
+---
+
+[ ] Add Base64 support: detect ?b64= param and auto-decode payloads.
+[ ] Implement Gist Loader: support ?gist=<id> to fetch and render external code.
+[ ] Enhance Sandboxing: toggle sandbox attribute for <iframe> (allow-scripts vs. strict).
+[x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
+[-] Improve UX: add “Edit ↻” button to sync textarea changes back to the URL. (Editor and Render button added, direct URL sync pending)
+[ ] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
+[ ] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
+[ ] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.
+[ ] Set up CSP Headers: configure safe Content-Security-Policy for public usage.
+[ ] Document API: detail query parameters and behaviors in README.
+
+---

--- a/index.html
+++ b/index.html
@@ -9,10 +9,42 @@
       const urlParams = new URLSearchParams(window.location.search);
       const htmlData = urlParams.get('data');
       const iframe = document.getElementById('iframe').contentWindow.document;
+      const htmlEditor = document.getElementById('htmlEditor'); // Moved up
 
       if (htmlData) {
         renderHTML(htmlData);
+      } else {
+        const editorContent = htmlEditor.value;
+        if (editorContent) {
+          renderHTML(editorContent);
+        }
       }
+
+      const renderButton = document.getElementById('renderButton');
+      const copyLinkButton = document.getElementById('copyLinkButton');
+
+      renderButton.addEventListener('click', () => {
+        const htmlContent = htmlEditor.value;
+        renderHTML(htmlContent);
+      });
+
+      copyLinkButton.addEventListener('click', () => {
+        const htmlContent = htmlEditor.value;
+        const encodedHtml = encodeURIComponent(htmlContent);
+        const baseUrl = window.location.origin + window.location.pathname;
+        const shareableLink = `${baseUrl}?data=${encodedHtml}`;
+
+        navigator.clipboard.writeText(shareableLink).then(() => {
+          const originalButtonText = copyLinkButton.textContent;
+          copyLinkButton.textContent = 'Copied!';
+          setTimeout(() => {
+            copyLinkButton.textContent = originalButtonText;
+          }, 2000); // Revert after 2 seconds
+        }).catch(err => {
+          console.error('Failed to copy link: ', err);
+          // You could also alert the user here if something goes wrong
+        });
+      });
 
       function renderHTML(html) {
         iframe.open();
@@ -38,6 +70,9 @@
   <div class="container mx-auto p-8">
     <h1 class="text-3xl font-bold mb-4">URL to HTML</h1>
     <p class="mb-4">Rendered HTML:</p>
+    <textarea id="htmlEditor" class="w-full h-64 border border-gray-300 rounded mb-4 p-2" placeholder="Type or paste your HTML here..."></textarea>
+    <button id="renderButton" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4">Render</button>
+    <button id="copyLinkButton" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Copy Link</button>
     <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)"></iframe>
   </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -8,11 +8,21 @@
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
       const htmlData = urlParams.get('data');
+      const b64Data = urlParams.get('b64'); // New: Get b64 parameter
       const iframe = document.getElementById('iframe').contentWindow.document;
-      const htmlEditor = document.getElementById('htmlEditor'); // Moved up
+      const htmlEditor = document.getElementById('htmlEditor');
 
       if (htmlData) {
         renderHTML(htmlData);
+      } else if (b64Data) { // New: Check for b64Data
+        try {
+          const decodedHtml = atob(b64Data);
+          renderHTML(decodedHtml);
+        } catch (error) {
+          console.error("Error decoding Base64 data: ", error);
+          // Optionally, render a specific error message in the iframe or clear it
+          // For now, it will just not render if b64 is malformed.
+        }
       } else {
         const editorContent = htmlEditor.value;
         if (editorContent) {

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
 
       const renderButton = document.getElementById('renderButton');
       const copyLinkButton = document.getElementById('copyLinkButton');
+      const clearEditorButton = document.getElementById('clearEditorButton'); // New button
 
       renderButton.addEventListener('click', () => {
         const htmlContent = htmlEditor.value;
@@ -54,6 +55,11 @@
           console.error('Failed to copy link: ', err);
           // You could also alert the user here if something goes wrong
         });
+      });
+
+      clearEditorButton.addEventListener('click', () => { // New event listener
+        htmlEditor.value = ''; // Clear the editor
+        renderHTML(''); // Clear the iframe
       });
 
       function renderHTML(html) {
@@ -83,6 +89,7 @@
     <textarea id="htmlEditor" class="w-full h-64 border border-gray-300 rounded mb-4 p-2" placeholder="Type or paste your HTML here..."></textarea>
     <button id="renderButton" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4">Render</button>
     <button id="copyLinkButton" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Copy Link</button>
+    <button id="clearEditorButton" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Clear Editor</button>
     <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)"></iframe>
   </div>
 </body>

--- a/index.html
+++ b/index.html
@@ -8,21 +8,57 @@
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
       const htmlData = urlParams.get('data');
-      const b64Data = urlParams.get('b64'); // New: Get b64 parameter
+      const b64Data = urlParams.get('b64');
+      const gistId = urlParams.get('gist'); // New: Get gist parameter
       const iframe = document.getElementById('iframe').contentWindow.document;
       const htmlEditor = document.getElementById('htmlEditor');
 
       if (htmlData) {
         renderHTML(htmlData);
-      } else if (b64Data) { // New: Check for b64Data
+      } else if (b64Data) {
         try {
           const decodedHtml = atob(b64Data);
           renderHTML(decodedHtml);
         } catch (error) {
           console.error("Error decoding Base64 data: ", error);
-          // Optionally, render a specific error message in the iframe or clear it
-          // For now, it will just not render if b64 is malformed.
         }
+      } else if (gistId) { // New: Check for gistId
+        console.log("Fetching Gist:", gistId);
+        fetch(`https://api.github.com/gists/${gistId}`)
+          .then(response => {
+            if (!response.ok) {
+              throw new Error(`GitHub API error: ${response.status}`);
+            }
+            return response.json();
+          })
+          .then(data => {
+            let htmlFileUrl = null;
+            for (const file of Object.values(data.files)) {
+              if (file.filename.endsWith('.html')) {
+                htmlFileUrl = file.raw_url;
+                break; 
+              }
+            }
+
+            if (htmlFileUrl) {
+              return fetch(htmlFileUrl);
+            } else {
+              console.error("No HTML file found in Gist");
+              throw new Error("No HTML file found in Gist"); // Stop promise chain
+            }
+          })
+          .then(response => {
+            if (!response.ok) { // This 'response' is from fetching the raw_url
+              throw new Error(`Error fetching Gist raw content: ${response.status}`);
+            }
+            return response.text();
+          })
+          .then(htmlText => {
+            renderHTML(htmlText);
+          })
+          .catch(error => {
+            console.error("Error fetching Gist content:", error);
+          });
       } else {
         const editorContent = htmlEditor.value;
         if (editorContent) {

--- a/index.html
+++ b/index.html
@@ -68,7 +68,9 @@
 
       const renderButton = document.getElementById('renderButton');
       const copyLinkButton = document.getElementById('copyLinkButton');
-      const clearEditorButton = document.getElementById('clearEditorButton'); // New button
+      const clearEditorButton = document.getElementById('clearEditorButton');
+      const sandboxToggle = document.getElementById('sandboxToggle'); // New toggle
+      const iframeElement = document.getElementById('iframe'); // Reference to the iframe element itself
 
       renderButton.addEventListener('click', () => {
         const htmlContent = htmlEditor.value;
@@ -96,6 +98,17 @@
       clearEditorButton.addEventListener('click', () => { // New event listener
         htmlEditor.value = ''; // Clear the editor
         renderHTML(''); // Clear the iframe
+      });
+
+      sandboxToggle.addEventListener('change', function() {
+        if (sandboxToggle.checked) {
+          iframeElement.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms';
+        } else {
+          iframeElement.sandbox = '';
+        }
+        // Re-render the current content with the new sandbox settings
+        const currentHtml = htmlEditor.value;
+        renderHTML(currentHtml);
       });
 
       function renderHTML(html) {
@@ -126,7 +139,11 @@
     <button id="renderButton" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4">Render</button>
     <button id="copyLinkButton" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Copy Link</button>
     <button id="clearEditorButton" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Clear Editor</button>
-    <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)"></iframe>
+    <div class="mb-4">
+      <input type="checkbox" id="sandboxToggle" class="mr-2">
+      <label for="sandboxToggle" class="text-sm text-gray-700">Allow Scripts (Relaxed Sandbox)</label>
+    </div>
+    <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)" sandbox=""></iframe>
   </div>
 </body>
 </html>


### PR DESCRIPTION
f
This commit introduces a feature to control the sandboxing policy
of the preview iframe.

Key changes:

1.  **Sandbox Control UI (`index.html`):**
    *   A checkbox labeled "Allow Scripts (Relaxed Sandbox)" has been
      added to the UI.

2.  **Default Strict Sandbox (`index.html`):**
    *   The `<iframe>` now defaults to `sandbox=""`, disabling scripts
      and other capabilities for enhanced security.

3.  **Toggle Functionality (`index.html` JavaScript):**
    *   When the "Allow Scripts" checkbox is checked, the iframe's
      sandbox attribute is updated to
      `allow-scripts allow-same-origin allow-popups allow-forms`.
    *   When unchecked, it reverts to `sandbox=""`.
    *   The iframe content is automatically re-rendered upon changing
      the sandbox policy to apply the new settings to the current HTML.

4.  **README.md Updates:**
    *   The new sandbox toggle feature is documented in the "Features"
      section and mentioned in the "API" (Live Editor and Tools) section.
    *   The "Enhance Sandboxing" item in the TODO list has been
      marked as complete (`[x]`).