### PR TITLE
update 

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,10 +34,10 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Update GitHub Actions versions for Pages deployment

- Updated `actions/upload-pages-artifact` from `v2` to `v3`
- Updated `actions/deploy-pages` from `v2` to `v4`

These changes  the actions to more current versions, which may help resolve or prevent potential issues related to GitHub Pages deployment.