### PR TITLE
Add Jest tests for utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ If you'd like to run Intuit locally:
 
 2. Open `index.html` in your web browser.
 
+### Running Tests
+
+Jest is used for the small test suite. Install dependencies and run:
+
+```sh
+npm install
+npm test
+```
+
 ## Technology Stack
 
 - HTML5

--- a/index.html
+++ b/index.html
@@ -4,12 +4,15 @@
   <meta charset="UTF-8">
   <title>URL to HTML</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const urlParams = new URLSearchParams(window.location.search);
-      const htmlData = urlParams.get('data');
-      const b64Data = urlParams.get('b64');
-      const gistId = urlParams.get('gist'); // New: Get gist parameter
+  <script type="module">
+    import { decodeDataParam, decodeB64Param, loadGist } from './utils.js';
+
+    document.addEventListener('DOMContentLoaded', async () => {
+      const search = window.location.search;
+      const urlParams = new URLSearchParams(search);
+      const htmlData = decodeDataParam(search);
+      const b64Data = decodeB64Param(search);
+      const gistId = urlParams.get('gist');
       const iframe = document.getElementById('iframe').contentWindow.document;
       const htmlEditor = document.getElementById('htmlEditor');
 
@@ -17,48 +20,17 @@
         renderHTML(htmlData);
       } else if (b64Data) {
         try {
-          const decodedHtml = atob(b64Data);
-          renderHTML(decodedHtml);
+          renderHTML(b64Data);
         } catch (error) {
           console.error("Error decoding Base64 data: ", error);
         }
-      } else if (gistId) { // New: Check for gistId
-        console.log("Fetching Gist:", gistId);
-        fetch(`https://api.github.com/gists/${gistId}`)
-          .then(response => {
-            if (!response.ok) {
-              throw new Error(`GitHub API error: ${response.status}`);
-            }
-            return response.json();
-          })
-          .then(data => {
-            let htmlFileUrl = null;
-            for (const file of Object.values(data.files)) {
-              if (file.filename.endsWith('.html')) {
-                htmlFileUrl = file.raw_url;
-                break; 
-              }
-            }
-
-            if (htmlFileUrl) {
-              return fetch(htmlFileUrl);
-            } else {
-              console.error("No HTML file found in Gist");
-              throw new Error("No HTML file found in Gist"); // Stop promise chain
-            }
-          })
-          .then(response => {
-            if (!response.ok) { // This 'response' is from fetching the raw_url
-              throw new Error(`Error fetching Gist raw content: ${response.status}`);
-            }
-            return response.text();
-          })
-          .then(htmlText => {
-            renderHTML(htmlText);
-          })
-          .catch(error => {
-            console.error("Error fetching Gist content:", error);
-          });
+      } else if (gistId) {
+        try {
+          const htmlText = await loadGist(gistId);
+          renderHTML(htmlText);
+        } catch (error) {
+          console.error("Error fetching Gist content:", error);
+        }
       } else {
         const editorContent = htmlEditor.value;
         if (editorContent) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "intuit",
+  "version": "1.0.0",
+  "description": "Intuit is a minimalist web tool that decodes and renders HTML content passed as a URL parameter. Created with an Apple-inspired design aesthetic, the tool provides a sleek interface for rendering HTML, which is then displayed in real-time within an iframe.",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "devDependencies": {
+    "jest": "^29.6.1"
+  }
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,32 @@
+import { decodeDataParam, decodeB64Param, loadGist } from '../utils.js';
+
+describe('utils', () => {
+  test('decodeDataParam extracts decoded HTML', () => {
+    const result = decodeDataParam('?data=%3Ch1%3EHi%3C/h1%3E');
+    expect(result).toBe('<h1>Hi</h1>');
+  });
+
+  test('decodeB64Param decodes base64 HTML', () => {
+    const result = decodeB64Param('?b64=PGgxPkhlbGxvPC9oMT4=');
+    expect(result).toBe('<h1>Hello</h1>');
+  });
+
+  test('loadGist fetches gist HTML', async () => {
+    const gistId = '123';
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          files: { 'index.html': { filename: 'index.html', raw_url: 'raw_url' } }
+        })
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: () => Promise.resolve('<div>Gist</div>')
+      });
+
+    const result = await loadGist(gistId);
+    expect(fetch).toHaveBeenCalledWith(`https://api.github.com/gists/${gistId}`);
+    expect(result).toBe('<div>Gist</div>');
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,34 @@
+export function decodeDataParam(urlSearch) {
+  const params = new URLSearchParams(urlSearch);
+  return params.get('data');
+}
+
+export function decodeB64Param(urlSearch) {
+  const params = new URLSearchParams(urlSearch);
+  const b64 = params.get('b64');
+  if (!b64) return null;
+  return atob(b64);
+}
+
+export async function loadGist(gistId) {
+  const response = await fetch(`https://api.github.com/gists/${gistId}`);
+  if (!response.ok) {
+    throw new Error(`GitHub API error: ${response.status}`);
+  }
+  const data = await response.json();
+  let htmlFileUrl = null;
+  for (const file of Object.values(data.files)) {
+    if (file.filename.endsWith('.html')) {
+      htmlFileUrl = file.raw_url;
+      break;
+    }
+  }
+  if (!htmlFileUrl) {
+    throw new Error('No HTML file found in Gist');
+  }
+  const rawResponse = await fetch(htmlFileUrl);
+  if (!rawResponse.ok) {
+    throw new Error(`Error fetching Gist raw content: ${rawResponse.status}`);
+  }
+  return await rawResponse.text();
+}


### PR DESCRIPTION
## Summary
- modularize query handling into `utils.js`
- use the new utilities from `index.html`
- add Jest test suite covering URL decoding and Gist loading
- document how to run the tests in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842420e66048325bef1fe0ae20f8884