### PR TITLE
Add Update URL button

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Beyond URL parameters, Intuit offers:
 *   **HTML Editor**: A textarea to directly type or paste HTML.
 *   **Render Button**: Renders the content from the HTML editor into the preview iframe.
 *   **Copy Link Button**: Generates a shareable URL with the current content of the HTML editor (URL-encoded into the `data` parameter) and copies it to the clipboard.
+*   **Update URL Button**: Replaces the page's `data` query parameter with the editor contents without reloading the page (using `history.replaceState`).
 *   **Sandbox Toggle**: A checkbox ("Allow Scripts") to switch the preview `iframe`'s sandbox settings. Unchecked (default) provides a strict sandbox. Checked allows scripts, same-origin operations, popups, and forms.
 
 ## Installation
@@ -114,7 +115,7 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 [x] Implement Gist Loader: support ?gist=<id> to fetch and render external code.
 [x] Enhance Sandboxing: toggle sandbox attribute for <iframe> (allow-scripts vs. strict).
 [x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
-[-] Improve UX: add “Edit ↻” button to sync textarea changes back to the URL. (Editor and Render button added, direct URL sync pending)
+[x] Add "Update URL" button: syncs textarea changes back to the `data` parameter via `history.replaceState`.
 [x] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
 [ ] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
 [ ] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.

--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
       const renderButton = document.getElementById('renderButton');
       const copyLinkButton = document.getElementById('copyLinkButton');
       const clearEditorButton = document.getElementById('clearEditorButton');
+      const updateUrlButton = document.getElementById('updateUrlButton');
       const sandboxToggle = document.getElementById('sandboxToggle'); // New toggle
       const iframeElement = document.getElementById('iframe'); // Reference to the iframe element itself
 
@@ -98,6 +99,14 @@
       clearEditorButton.addEventListener('click', () => { // New event listener
         htmlEditor.value = ''; // Clear the editor
         renderHTML(''); // Clear the iframe
+      });
+
+      updateUrlButton.addEventListener('click', () => {
+        const htmlContent = htmlEditor.value;
+        const encodedHtml = encodeURIComponent(htmlContent);
+        const baseUrl = window.location.origin + window.location.pathname;
+        const newUrl = `${baseUrl}?data=${encodedHtml}`;
+        history.replaceState(null, '', newUrl);
       });
 
       sandboxToggle.addEventListener('change', function() {
@@ -139,6 +148,7 @@
     <button id="renderButton" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4">Render</button>
     <button id="copyLinkButton" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Copy Link</button>
     <button id="clearEditorButton" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Clear Editor</button>
+    <button id="updateUrlButton" class="bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Update URL</button>
     <div class="mb-4">
       <input type="checkbox" id="sandboxToggle" class="mr-2">
       <label for="sandboxToggle" class="text-sm text-gray-700">Allow Scripts (Relaxed Sandbox)</label>


### PR DESCRIPTION
## Summary
- add Update URL button next to existing buttons
- hook up `history.replaceState` to update the `data` query parameter
- document the new button in README
- mark TODO item complete

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_684241eb9314832598e55b89f0d889be