### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Intuit is a minimalist web tool that decodes and renders HTML content passed as 
 - Real-time rendering of HTML within an iframe.
 - Clean and user-friendly interface for ease of use.
 - **Configurable Sandbox:** Control the `iframe` sandbox policy. By default, scripts are disabled for security. A toggle allows enabling scripts (`allow-scripts`, `allow-same-origin`, `allow-popups`, `allow-forms`) for testing snippets that require them. Use with caution with untrusted HTML.
+- **Theme Toggle:** Switch between light and dark modes. Preference is saved in local storage.
 
 ## Intuit for LLM-Powered Agents
 
@@ -75,6 +76,7 @@ Beyond URL parameters, Intuit offers:
 *   **Render Button**: Renders the content from the HTML editor into the preview iframe.
 *   **Copy Link Button**: Generates a shareable URL with the current content of the HTML editor (URL-encoded into the `data` parameter) and copies it to the clipboard.
 *   **Sandbox Toggle**: A checkbox ("Allow Scripts") to switch the preview `iframe`'s sandbox settings. Unchecked (default) provides a strict sandbox. Checked allows scripts, same-origin operations, popups, and forms.
+*   **Theme Toggle**: Switch between light and dark modes.
 
 ## Installation
 
@@ -116,7 +118,7 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 [x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
 [-] Improve UX: add “Edit ↻” button to sync textarea changes back to the URL. (Editor and Render button added, direct URL sync pending)
 [x] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
-[ ] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
+[x] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
 [ ] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.
 [ ] Set up CSP Headers: configure safe Content-Security-Policy for public usage.
 [x] Document API: detail query parameters and behaviors in README.

--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
   <title>URL to HTML</title>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" rel="stylesheet">
   <script>
+    if (localStorage.theme === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+  </script>
+  <script>
     document.addEventListener('DOMContentLoaded', () => {
       const urlParams = new URLSearchParams(window.location.search);
       const htmlData = urlParams.get('data');
@@ -71,6 +78,20 @@
       const clearEditorButton = document.getElementById('clearEditorButton');
       const sandboxToggle = document.getElementById('sandboxToggle'); // New toggle
       const iframeElement = document.getElementById('iframe'); // Reference to the iframe element itself
+      const themeToggle = document.getElementById('themeToggle');
+
+      // Initialize theme toggle state
+      themeToggle.checked = document.documentElement.classList.contains('dark');
+
+      themeToggle.addEventListener('change', () => {
+        if (themeToggle.checked) {
+          document.documentElement.classList.add('dark');
+          localStorage.setItem('theme', 'dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+          localStorage.setItem('theme', 'light');
+        }
+      });
 
       renderButton.addEventListener('click', () => {
         const htmlContent = htmlEditor.value;
@@ -131,19 +152,23 @@
     }
   </script>
 </head>
-<body class="font-sans antialiased bg-gray-100 text-gray-800">
+<body class="font-sans antialiased bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
   <div class="container mx-auto p-8">
     <h1 class="text-3xl font-bold mb-4">URL to HTML</h1>
     <p class="mb-4">Rendered HTML:</p>
-    <textarea id="htmlEditor" class="w-full h-64 border border-gray-300 rounded mb-4 p-2" placeholder="Type or paste your HTML here..."></textarea>
+    <textarea id="htmlEditor" class="w-full h-64 border border-gray-300 rounded mb-4 p-2 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-600" placeholder="Type or paste your HTML here..."></textarea>
     <button id="renderButton" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4">Render</button>
     <button id="copyLinkButton" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Copy Link</button>
     <button id="clearEditorButton" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Clear Editor</button>
     <div class="mb-4">
       <input type="checkbox" id="sandboxToggle" class="mr-2">
-      <label for="sandboxToggle" class="text-sm text-gray-700">Allow Scripts (Relaxed Sandbox)</label>
+      <label for="sandboxToggle" class="text-sm text-gray-700 dark:text-gray-300">Allow Scripts (Relaxed Sandbox)</label>
     </div>
-    <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)" sandbox=""></iframe>
+    <div class="mb-4">
+      <input type="checkbox" id="themeToggle" class="mr-2">
+      <label for="themeToggle" class="text-sm text-gray-700 dark:text-gray-300">Dark Mode</label>
+    </div>
+    <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded dark:border-gray-600" onload="htmz(this)" sandbox=""></iframe>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add theme toggle using Tailwind's dark mode utilities
- persist preference using local storage
- document theme toggle in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684241e5d5288325b62868f44423ce4d