### PR TITLE
Add dark mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Intuit is a minimalist web tool that decodes and renders HTML content passed as 
 - Real-time rendering of HTML within an iframe.
 - Clean and user-friendly interface for ease of use.
 - **Configurable Sandbox:** Control the `iframe` sandbox policy. By default, scripts are disabled for security. A toggle allows enabling scripts (`allow-scripts`, `allow-same-origin`, `allow-popups`, `allow-forms`) for testing snippets that require them. Use with caution with untrusted HTML.
+- **Dark Mode:** Switch between light and dark themes for comfortable viewing.
 
 ## Intuit for LLM-Powered Agents
 
@@ -117,7 +118,7 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 [x] Add Copy Link button: encode current editor content and copy full URL to clipboard.
 [x] Add "Update URL" button: syncs textarea changes back to the `data` parameter via `history.replaceState`.
 [x] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
-[ ] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
+[x] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
 [ ] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.
 [ ] Set up CSP Headers: configure safe Content-Security-Policy for public usage.
 [x] Document API: detail query parameters and behaviors in README.

--- a/index.html
+++ b/index.html
@@ -90,7 +90,15 @@
       const clearEditorButton = document.getElementById('clearEditorButton');
       const updateUrlButton = document.getElementById('updateUrlButton');
       const sandboxToggle = document.getElementById('sandboxToggle'); // New toggle
+      const themeToggle = document.getElementById('themeToggle'); // Dark/light theme toggle
       const iframeElement = document.getElementById('iframe'); // Reference to the iframe element itself
+
+      // Initialize theme based on localStorage
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'dark') {
+        document.documentElement.classList.add('dark');
+        themeToggle.checked = true;
+      }
 
       renderButton.addEventListener('click', () => {
         const htmlContent = htmlEditor.value;
@@ -139,6 +147,16 @@
         renderHTML(currentHtml);
       });
 
+      themeToggle.addEventListener('change', function() {
+        if (themeToggle.checked) {
+          document.documentElement.classList.add('dark');
+          localStorage.setItem('theme', 'dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+          localStorage.setItem('theme', 'light');
+        }
+      });
+
       function renderHTML(html) {
         iframe.open();
         iframe.write(html);
@@ -159,7 +177,7 @@
     }
   </script>
 </head>
-<body class="font-sans antialiased bg-gray-100 text-gray-800">
+<body class="font-sans antialiased bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-100">
     <div class="container mx-auto p-8">
       <h1 class="text-3xl font-bold mb-4">URL to HTML</h1>
       <div id="errorMessage" class="hidden bg-red-100 border border-red-400 text-red-700 px-4 py-2 rounded mb-4"></div>
@@ -168,12 +186,16 @@
     <button id="renderButton" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded mb-4">Render</button>
     <button id="copyLinkButton" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Copy Link</button>
     <button id="clearEditorButton" class="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Clear Editor</button>
-    <button id="updateUrlButton" class="bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Update URL</button>
-    <div class="mb-4">
-      <input type="checkbox" id="sandboxToggle" class="mr-2">
-      <label for="sandboxToggle" class="text-sm text-gray-700">Allow Scripts (Relaxed Sandbox)</label>
+      <button id="updateUrlButton" class="bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded mb-4 ml-2">Update URL</button>
+      <div class="mb-4">
+        <input type="checkbox" id="sandboxToggle" class="mr-2">
+        <label for="sandboxToggle" class="text-sm text-gray-700 dark:text-gray-300">Allow Scripts (Relaxed Sandbox)</label>
+      </div>
+      <div class="mb-4">
+        <input type="checkbox" id="themeToggle" class="mr-2">
+        <label for="themeToggle" class="text-sm text-gray-700 dark:text-gray-300">Dark Mode</label>
+      </div>
+      <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)" sandbox=""></iframe>
     </div>
-    <iframe id="iframe" name="htmz" class="w-full h-96 border border-gray-300 rounded" onload="htmz(this)" sandbox=""></iframe>
-  </div>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- add dark mode toggle to the UI
- mark dark theme TODO as complete and document dark mode in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ea957b6248325a3dd3a07c212e76d