### PR TITLE
Implement CSP and add node tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ Franklin Silveira Baldo - [Github](https://github.com/franklinbaldo)
 [x] Add "Update URL" button: syncs textarea changes back to the `data` parameter via `history.replaceState`.
 [x] Add "Clear Editor" button: Provides a button to easily clear the content of the HTML textarea.
 [x] Add Dark/Light Themes: Tailwind-based theme switcher for previews.
-[ ] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.
-[ ] Set up CSP Headers: configure safe Content-Security-Policy for public usage.
+[x] Write Unit Tests: simple JS tests for encoding/decoding and iframe injection.
+[x] Set up CSP Headers: configure safe Content-Security-Policy for public usage.
 [x] Document API: detail query parameters and behaviors in README.
 
 ---

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline';" />
     <title>URL to HTML</title>
     <link
       href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "intuit",
+  "version": "1.0.0",
+  "description": "Intuit is a minimalist web tool that decodes and renders HTML content passed as a URL parameter. Created with an Apple-inspired design aesthetic, the tool provides a sleek interface for rendering HTML, which is then displayed in real-time within an iframe.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,20 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { decodeBase64, renderHTML } = require('../utils');
+
+test('decodeBase64 decodes Base64 strings', () => {
+  const input = 'PGgxPkhlbGxvPC9oMT4='; // <h1>Hello</h1>
+  const expected = '<h1>Hello</h1>';
+  assert.strictEqual(decodeBase64(input), expected);
+});
+
+test('renderHTML writes HTML to provided document', () => {
+  const doc = {
+    content: '',
+    open(){ this.content = ''; },
+    write(str){ this.content += str; },
+    close(){}
+  };
+  renderHTML(doc, '<p>Test</p>');
+  assert.strictEqual(doc.content, '<p>Test</p>');
+});

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,24 @@
+(function(global){
+  function decodeBase64(str){
+    if (typeof Buffer !== 'undefined'){
+      return Buffer.from(str, 'base64').toString('utf-8');
+    }
+    return atob(str);
+  }
+
+  function renderHTML(doc, html){
+    if(!doc || typeof doc.open !== 'function' || typeof doc.write !== 'function' || typeof doc.close !== 'function'){
+      throw new Error('Invalid document');
+    }
+    doc.open();
+    doc.write(html);
+    doc.close();
+  }
+
+  if(typeof module !== 'undefined' && module.exports){
+    module.exports = { decodeBase64, renderHTML };
+  }else{
+    global.decodeBase64 = decodeBase64;
+    global.renderHTML = renderHTML;
+  }
+})(typeof window !== 'undefined' ? window : global);


### PR DESCRIPTION
## Summary
- add CSP meta tag for security
- create simple utils module with decode and iframe rendering helpers
- add node-based unit tests for utils
- update README TODOs as complete

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686981920e548325b69f88d8a5825c86