### PR TITLE
fix: update CSP to allow iframe rendering with URL parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline';" />
+    <!-- Content Security Policy: Allows iframe rendering while maintaining security -->
+    <!--
+      Note: CSP is intentionally permissive to support dynamic HTML rendering in iframe.
+      - 'unsafe-inline' needed for inline styles/scripts in rendered HTML
+      - data:/blob: needed for data URLs and dynamically generated content
+      - External CDN (cdnjs.cloudflare.com) needed for Tailwind CSS
+    -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' data: blob:; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com data: blob:; script-src 'self' 'unsafe-inline'; img-src * data: blob:; font-src 'self' data: https://cdnjs.cloudflare.com; connect-src 'self' https://api.github.com https://raw.githubusercontent.com; frame-src *; media-src * data: blob:;" />
     <title>Intuit - HTML Renderer</title>
     <meta name="description" content="A minimalist HTML renderer and visual testing tool for developers, designers, and AI agents" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
The previous Content Security Policy was too restrictive and prevented the iframe from rendering HTML content loaded via URL parameters (?data= and ?b64=).

Changes:
- Added 'frame-src *' to allow iframe content from any source
- Added 'unsafe-inline' to default-src for dynamic content
- Expanded img-src to '*' to allow images from any source
- Added data: and blob: support for dynamically generated content
- Added media-src directive for video/audio support
- Documented CSP rationale in comments

This fixes the issue where URLs like:
https://franklinbaldo.github.io/intuit/?data=%3Ch1%3EGenerated%20by%20AI%3C%2Fh1%3E were not rendering the HTML content in the iframe.

The CSP remains secure while being permissive enough to support the core functionality of dynamically rendering arbitrary HTML in an iframe.