### PR TITLE
fix: name and structure the preview surface (#16)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: npm
       - name: Install dependencies
-        run: npm ci
+        run: npm install
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
       - name: Unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+      - name: Unit tests
+        run: npm test
+      - name: Playwright tests
+        run: npm run test:playwright

--- a/index.html
+++ b/index.html
@@ -278,18 +278,19 @@
         </div>
 
         <!-- Preview Section -->
-        <div>
-          <label class="block text-sm font-semibold mb-2 text-gray-700 dark:text-gray-300">
+        <section aria-labelledby="previewHeading">
+          <h2 id="previewHeading" class="block text-sm font-semibold mb-2 text-gray-700 dark:text-gray-300">
             Preview
-          </label>
+          </h2>
           <iframe
             id="iframe"
             name="htmz"
+            title="Rendered HTML preview"
             class="w-full h-96 border-2 border-gray-300 dark:border-gray-600 rounded-lg bg-white shadow-inner"
             onload="htmz(this)"
             sandbox=""
           ></iframe>
-        </div>
+        </section>
       </div>
 
       <!-- Footer -->

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <meta name="description" content="A minimalist HTML renderer and visual testing tool for developers, designers, and AI agents" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link
-      href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind-dark.min.css"
       rel="stylesheet"
     />
     <script>
@@ -44,7 +44,9 @@
           htmlEditor.value = htmlData; // Populate editor with loaded HTML
         } else if (b64Data) {
           try {
-            const decodedHtml = atob(b64Data);
+            // URLSearchParams decodes `+` as a space. Restore raw Base64
+            // semantics so existing `?b64=` links round-trip exactly.
+            const decodedHtml = atob(b64Data.replace(/ /g, "+"));
             renderHTML(decodedHtml);
             htmlEditor.value = decodedHtml; // Populate editor with loaded HTML
           } catch (error) {

--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
     </script>
   </head>
   <body
-    class="font-sans antialiased bg-gradient-to-br from-gray-50 to-gray-100 text-gray-800 dark:from-gray-900 dark:to-gray-800 dark:text-gray-100 min-h-screen"
+    class="font-sans antialiased bg-gray-50 bg-gradient-to-br from-gray-50 to-gray-100 text-gray-800 dark:bg-gray-900 dark:from-gray-900 dark:to-gray-800 dark:text-gray-100 min-h-screen"
   >
     <div class="container mx-auto p-4 sm:p-8 max-w-7xl">
       <!-- Header Section -->

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
         const htmlData = urlParams.get("data");
         const b64Data = urlParams.get("b64");
         const gistId = urlParams.get("gist"); // New: Get gist parameter
-        const iframe = document.getElementById("iframe").contentWindow.document;
+        const iframeElement = document.getElementById("iframe");
         const htmlEditor = document.getElementById("htmlEditor");
         const errorMessage = document.getElementById("errorMessage");
 
@@ -108,7 +108,6 @@
         const updateUrlButton = document.getElementById("updateUrlButton");
         const sandboxToggle = document.getElementById("sandboxToggle"); // New toggle
         const themeToggle = document.getElementById("themeToggle"); // Dark/light theme toggle
-        const iframeElement = document.getElementById("iframe"); // Reference to the iframe element itself
 
         // Initialize theme based on localStorage
         const savedTheme = localStorage.getItem("theme");
@@ -159,10 +158,12 @@
 
         sandboxToggle.addEventListener("change", function () {
           if (sandboxToggle.checked) {
-            iframeElement.sandbox =
-              "allow-scripts allow-same-origin allow-popups allow-forms";
+            iframeElement.setAttribute(
+              "sandbox",
+              "allow-scripts allow-same-origin allow-popups allow-forms",
+            );
           } else {
-            iframeElement.sandbox = "";
+            iframeElement.setAttribute("sandbox", "");
           }
           // Re-render the current content with the new sandbox settings
           const currentHtml = htmlEditor.value;
@@ -180,19 +181,28 @@
         });
 
         function renderHTML(html) {
-          iframe.open();
-          iframe.write(html);
-          iframe.close();
+          // `sandbox=""` gives the frame an opaque origin, so parent-side access
+          // to contentDocument is intentionally unavailable. srcdoc lets the
+          // parent replace the rendered document without weakening that sandbox.
+          iframeElement.srcdoc = html;
         }
       });
 
       function htmz(frame) {
         setTimeout(() => {
-          const hash = frame.contentWindow.location.hash;
-          if (hash) {
-            const element = frame.contentDocument.querySelector(hash);
-            if (element) {
-              element.replaceWith(...frame.contentDocument.body.childNodes);
+          try {
+            const hash = frame.contentWindow.location.hash;
+            if (hash) {
+              const element = frame.contentDocument.querySelector(hash);
+              if (element) {
+                element.replaceWith(...frame.contentDocument.body.childNodes);
+              }
+            }
+          } catch (error) {
+            // A strict sandbox intentionally has an opaque origin. Hash-based
+            // htmz replacement is optional and should not break normal preview.
+            if (frame.getAttribute("sandbox") !== "") {
+              console.error("Unable to process iframe hash:", error);
             }
           }
         }, 0);

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -29,9 +29,9 @@ module.exports = defineConfig({
     },
   ],
 
-  // webServer: {
-  //   command: 'npx http-server -p 8080',
-  //   url: 'http://localhost:8080',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npx http-server -p 8080',
+    url: 'http://localhost:8080',
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/tests/playwright/accessibility.spec.js
+++ b/tests/playwright/accessibility.spec.js
@@ -1,0 +1,12 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Workspace accessibility semantics', () => {
+  test('names the rendered preview surface and exposes it as a section', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByRole('heading', { name: 'Preview', level: 2 })).toBeVisible();
+    await expect(page.locator('section[aria-labelledby="previewHeading"]')).toBeVisible();
+    await expect(page.locator('#iframe')).toHaveAttribute('title', 'Rendered HTML preview');
+    await expect(page.locator('label', { hasText: 'Preview' })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Closes #16. Closes #18. Closes #19. Closes #20. Closes #21.

## O que muda

- troca o `<label>` solto de `Preview` por um heading real dentro de uma `<section>` e dá nome acessível ao iframe;
- adiciona CI separado de Pages para executar `npm test` + Playwright em PRs e em `main`;
- torna a suíte realmente executável em CI (sem pressupor lockfile e com `webServer` controlado pelo Playwright);
- corrige o runtime revelado pelo novo gate: preview estritamente sandboxed passa a ser preenchido via `srcdoc`, sem acesso parent-side a `contentDocument`, e o toggle atualiza o atributo `sandbox` explicitamente;
- preserva Base64 cru em `?b64=` normalizando o `+` que `URLSearchParams` converte em espaço;
- troca para o build `tailwind-dark.min.css` 2.2.19, correspondente ao contrato de tema por classe que o markup/toggle já usam.

## Por que

A relação central do Intuit é editor → resultado renderizado. Ao tornar a suíte existente um gate real, ela deixou de ser documentação aspiracional e passou a falsificar o produto: primeiro revelou que 38/49 testes falhavam por uma dependência indevida do documento de um iframe com origem opaca. Depois dessa correção, 47/49 passaram e sobraram dois bugs independentes e reproduzíveis: round-trip Base64 com `+` e tema lógico sem consequência visual.

## Evidência negativa preservada

- `npm ci` não era hipótese válida: o repo não possui lockfile;
- o `webServer` Playwright estava comentado;
- com a suíte executável, 38/49 testes falharam no boot do runtime;
- após `srcdoc`, 47/49 passaram, isolando Base64 e dark-mode como defects próprios.

Nenhum teste foi removido, pulado ou rebaixado para obter verde.

## Fronteira

Sem redesign: preserva estética local, share URLs e scripts opt-in. O modo default continua estritamente sandboxed; o workflow Pages continua separado e inalterado.